### PR TITLE
プロジェクト関連機能の強化

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Creates a new project in Linear.
   description?: string;  // Optional: Project description
   content?: string;      // Optional: Project content in markdown format
   leadId?: string;       // Optional: Project lead user ID (未指定の場合は自分がリードに設定されます)
+  statusId?: string;     // Optional: Project status ID
 }
 ```
 
@@ -180,6 +181,7 @@ Updates an existing project in Linear.
   description?: string;  // Optional: New project description
   content?: string;      // Optional: New project content in markdown format
   leadId?: string;       // Optional: New project lead user ID
+  statusId?: string;     // Optional: New project status ID
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,20 @@ Gets detailed information about a specific project, including teams, issues, and
 }
 ```
 
+#### create_project
+
+Creates a new project in Linear.
+
+```typescript
+{
+  name: string;          // Required: Project name
+  teamId: string;        // Required: Team ID
+  description?: string;  // Optional: Project description
+  content?: string;      // Optional: Project content in markdown format
+  leadId?: string;       // Optional: Project lead user ID (未指定の場合は自分がリードに設定されます)
+}
+```
+
 ## Prerequisites
 
 - Node.js (v16 or higher)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Retrieves a list of labels associated with a team.
 
 ```typescript
 {
-  teamId: string;      // Required: Team ID
+  teamId: string; // Required: Team ID
 }
 ```
 
@@ -58,7 +58,7 @@ Displays a list of workflow states for a specific team.
 
 ```typescript
 {
-  teamId: string;      // Required: Team ID
+  teamId: string; // Required: Team ID
 }
 ```
 
@@ -141,7 +141,17 @@ Gets detailed information about a specific issue.
 
 ```typescript
 {
-  issueId: string;     // Required: Issue ID
+  issueId: string; // Required: Issue ID
+}
+```
+
+#### get_project
+
+Gets detailed information about a specific project, including teams, issues, and members.
+
+```typescript
+{
+  projectId: string; // Required: Project ID
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,20 @@ Creates a new project in Linear.
 }
 ```
 
+#### update_project
+
+Updates an existing project in Linear.
+
+```typescript
+{
+  projectId: string;     // Required: Project ID
+  name?: string;         // Optional: New project name
+  description?: string;  // Optional: New project description
+  content?: string;      // Optional: New project content in markdown format
+  leadId?: string;       // Optional: New project lead user ID
+}
+```
+
 ## Prerequisites
 
 - Node.js (v16 or higher)

--- a/README.md
+++ b/README.md
@@ -185,6 +185,10 @@ Updates an existing project in Linear.
 }
 ```
 
+#### list_project_statuses
+
+Retrieves a list of available project statuses that can be assigned to projects.
+
 ## Prerequisites
 
 - Node.js (v16 or higher)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@texmeijin/linear-enhanced-mcp",
+  "name": "@ibraheem4/linear-mcp",
   "version": "78.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@texmeijin/linear-enhanced-mcp",
+      "name": "@ibraheem4/linear-mcp",
       "version": "78.0.1",
       "license": "MIT",
       "dependencies": {
@@ -14,7 +14,7 @@
         "dotenv": "16.4.7"
       },
       "bin": {
-        "linear-enhanced-mcp": "build/index.js"
+        "linear-mcp": "build/index.js"
       },
       "devDependencies": {
         "@types/node": "^20.11.24",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@ibraheem4/linear-mcp",
+  "name": "@texmeijin/linear-enhanced-mcp",
   "version": "78.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@ibraheem4/linear-mcp",
+      "name": "@texmeijin/linear-enhanced-mcp",
       "version": "78.0.1",
       "license": "MIT",
       "dependencies": {
@@ -14,7 +14,7 @@
         "dotenv": "16.4.7"
       },
       "bin": {
-        "linear-mcp": "build/index.js"
+        "linear-enhanced-mcp": "build/index.js"
       },
       "devDependencies": {
         "@types/node": "^20.11.24",

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,7 @@ const baseTools = [
   "get_project",
   "create_project",
   "update_project",
+  "list_project_statuses",
 ];
 baseTools.forEach((tool) => {
   toolsCapabilities[tool] = true;
@@ -459,6 +460,14 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
           },
           required: ["projectId"],
+        },
+      },
+      {
+        name: "list_project_statuses",
+        description: "プロジェクトに指定できるステータスの一覧を取得",
+        inputSchema: {
+          type: "object",
+          properties: {},
         },
       },
     ],
@@ -1273,6 +1282,30 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             {
               type: "text",
               text: JSON.stringify(updatedProject, null, 2),
+            },
+          ],
+        };
+      }
+
+      case "list_project_statuses": {
+        const statuses = await linearClient.projectStatuses();
+
+        const formattedStatuses = await Promise.all(
+          statuses.nodes.map(async (status) => {
+            return {
+              id: status.id,
+              name: status.name,
+              description: status.description,
+              type: status.type,
+            };
+          })
+        );
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(formattedStatuses, null, 2),
             },
           ],
         };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1239,8 +1239,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const project = await linearClient.createProject({
           name: args.name,
           teamIds: [args.teamId],
-          description: args.description || "",
-          content: args.content || "",
+          description: args.description || undefined,
+          content: args.content || undefined,
           leadId: leadId,
           statusId: args.statusId,
         });
@@ -1270,8 +1270,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           args.projectId,
           {
             name: args.name,
-            description: args.description || "",
-            content: args.content || "",
+            description: args.description || undefined,
+            content: args.content || undefined,
             leadId: args.leadId,
             statusId: args.statusId,
           }
@@ -1290,17 +1290,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       case "list_project_statuses": {
         const statuses = await linearClient.projectStatuses();
 
-        const formattedStatuses = await Promise.all(
-          statuses.nodes.map(async (status) => {
-            return {
-              id: status.id,
-              name: status.name,
-              description: status.description,
-              type: status.type,
-            };
-          })
-        );
-
+        const formattedStatuses = statuses.nodes.map((status) => {
+          return {
+            id: status.id,
+            name: status.name,
+            description: status.description,
+            type: status.type,
+          };
+        });
         return {
           content: [
             {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1160,10 +1160,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         }
 
         // 詳細情報を取得
-        const [teams, issues, members] = await Promise.all([
+        const [teams, issues, members, externalLinks] = await Promise.all([
           project.teams(),
           project.issues({ first: 50 }),
           project.members(),
+          project.externalLinks(),
         ]);
 
         // プロジェクトの詳細情報を整形
@@ -1181,14 +1182,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           completedAt: project.completedAt,
           progress: project.progress,
           teams: await Promise.all(
-            teams.nodes.map(async (team: any) => ({
+            teams.nodes.map(async (team) => ({
               id: team.id,
               name: team.name,
               key: team.key,
             }))
           ),
           issues: await Promise.all(
-            issues.nodes.map(async (issue: any) => {
+            issues.nodes.map(async (issue) => {
               const state = await issue.state;
               return {
                 id: issue.id,
@@ -1200,10 +1201,17 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             })
           ),
           members: await Promise.all(
-            members.nodes.map(async (member: any) => ({
+            members.nodes.map(async (member) => ({
               id: member.id,
               name: member.name,
               displayName: member.displayName,
+            }))
+          ),
+          externalLinks: await Promise.all(
+            externalLinks.nodes.map(async (externalLink) => ({
+              id: externalLink.id,
+              label: externalLink.label,
+              url: externalLink.url,
             }))
           ),
         };

--- a/src/index.ts
+++ b/src/index.ts
@@ -171,7 +171,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             labels: {
               type: "array",
               items: {
-                type: "string"
+                type: "string",
               },
               description: "ラベルIDの配列（オプション）、指定したラベルで置き換えられます",
             },
@@ -319,9 +319,9 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             teamId: {
               type: "string",
               description: "チームID",
-            }
+            },
           },
-          required: ["teamId"]
+          required: ["teamId"],
         },
       },
       {
@@ -333,9 +333,9 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             teamId: {
               type: "string",
               description: "チームID",
-            }
+            },
           },
-          required: ["teamId"]
+          required: ["teamId"],
         },
       },
       {
@@ -699,7 +699,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             autoArchivedAt: Date | null;
             autoClosedAt: Date | null;
             trashed: boolean;
-            relations: Array<{ id: string; type: string; issue: { id: string; title: string } }>;
+            relations: Array<{
+              id: string;
+              type: string;
+              issue: { id: string; title: string };
+            }>;
           } = {
             id: issue.id,
             identifier: issue.identifier,
@@ -795,7 +799,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
               issue: {
                 id: relation.issue.id,
                 title: relation.issue.title,
-              }
+              },
             })),
           };
 
@@ -814,12 +818,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
           // Add image analysis for attachments if they are images
           issueDetails.attachments = await Promise.all(
-            attachments.nodes
-              .map(async (attachment: any) => ({
-                id: attachment.id,
-                title: attachment.title,
-                url: attachment.url,
-              }))
+            attachments.nodes.map(async (attachment: any) => ({
+              id: attachment.id,
+              title: attachment.title,
+              url: attachment.url,
+            }))
           );
 
           return {
@@ -936,7 +939,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           type: state.type,
           position: state.position,
           description: state.description,
-          teamId: team.id
+          teamId: team.id,
         }));
 
         return {
@@ -1009,9 +1012,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         }
 
         // 詳細情報を取得
-        const [teams, issues] = await Promise.all([
+        const [teams, issues, members] = await Promise.all([
           project.teams(),
           project.issues({ first: 50 }),
+          project.members(),
         ]);
 
         // プロジェクトの詳細情報を整形
@@ -1046,6 +1050,13 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                 priority: issue.priority,
               };
             })
+          ),
+          members: await Promise.all(
+            members.nodes.map(async (member: any) => ({
+              id: member.id,
+              name: member.name,
+              displayName: member.displayName,
+            }))
           ),
         };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -419,6 +419,10 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
               description:
                 "Project lead user ID (optional, 未指定の場合は自分がリードに設定されます)",
             },
+            statusId: {
+              type: "string",
+              description: "Project status ID (optional)",
+            },
           },
           required: ["name", "teamId"],
         },
@@ -448,6 +452,10 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             leadId: {
               type: "string",
               description: "New project lead user ID (optional)",
+            },
+            statusId: {
+              type: "string",
+              description: "New project status ID (optional)",
             },
           },
           required: ["projectId"],
@@ -540,6 +548,7 @@ type CreateProjectArgs = {
   description?: string;
   content?: string;
   leadId?: string;
+  statusId?: string;
 };
 
 type UpdateProjectArgs = {
@@ -548,6 +557,7 @@ type UpdateProjectArgs = {
   description?: string;
   content?: string;
   leadId?: string;
+  statusId?: string;
 };
 
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
@@ -1220,9 +1230,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const project = await linearClient.createProject({
           name: args.name,
           teamIds: [args.teamId],
-          description: args.description,
-          content: args.content,
+          description: args.description || "",
+          content: args.content || "",
           leadId: leadId,
+          statusId: args.statusId,
         });
 
         return {
@@ -1250,9 +1261,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           args.projectId,
           {
             name: args.name,
-            description: args.description,
-            content: args.content,
+            description: args.description || "",
+            content: args.content || "",
             leadId: args.leadId,
+            statusId: args.statusId,
           }
         );
 


### PR DESCRIPTION
## PR 概要

Linear MCP サーバーのプロジェクト関連機能を強化する改善

### 主な変更点

1. **プロジェクトステータス機能の強化**

   - `create_project` と `update_project` でステータス ID を指定できるようになりました
   - プロジェクト作成・更新時に `statusId` パラメータを受け付けるように対応

2. **プロジェクトステータス一覧取得ツールの追加**

   - `list_project_statuses` ツールを新規追加
   - プロジェクトに設定可能な全ステータスの一覧を取得可能に

3. **プロジェクト詳細情報の拡充**
   - `get_project` レスポンスに外部リンク情報を追加
   - プロジェクトに関連付けられた外部リンクの情報（ID、ラベル、URL）を取得可能に

これらの改善により、Linear 上のプロジェクト管理をより柔軟に行えるようになります。
